### PR TITLE
git-clone-all.sh

### DIFF
--- a/scripts/git-clone-all.sh
+++ b/scripts/git-clone-all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+REPOSITORIES=(DNC-DShop DNC-DShop.Api DNC-DShop.Common DNC-DShop.Messages DNC-DShop.Services.Customers DNC-DShop.Services.Identity DNC-DShop.Services.Notifications DNC-DShop.Services.Operations DNC-DShop.Services.Orders DNC-DShop.Services.Products DNC-DShop.Services.Signalr DNC-DShop.Services.Storage DNC-DShop.Monolith DNC-DShop.Web)
+cd ../..
+pwd
+for REPOSITORY in ${REPOSITORIES[*]}
+do
+	 echo ========================================================
+	 echo Cloning repository: $REPOSITORY
+	 echo ========================================================
+	 REPO_URL=https://github.com/devmentors/$REPOSITORY.git
+	 git clone $REPO_URL
+done


### PR DESCRIPTION
Script for cloning all DNC-DShop projects from github.
Based on git-pull-all.sh, but added missing repos (DNC-DShop.Monolith DNC-DShop.Web).