### PR TITLE
added alternate docker-compose-infrastructure with volumes 

### DIFF
--- a/compose/docker-compose-infrastructure.volumes.yml
+++ b/compose/docker-compose-infrastructure.volumes.yml
@@ -1,0 +1,41 @@
+version: "3.5"
+
+services:
+  mongo:
+    image: mongo:4
+    container_name: mongo
+    ports:
+      - '27017:27017'
+    networks:
+      - dshop
+    volumes:
+      - mongovol:/data/db
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    networks:
+      - dshop
+    volumes: 
+      - rabbitmqvol:/var/lib/rabbitmq
+
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - '6379:6379'
+    networks:
+      - dshop
+    volumes: 
+      - redisvol:/data
+
+volumes:
+  mongovol:
+  rabbitmqvol:
+  redisvol:
+networks:
+  dshop:
+    name: dshop-network

--- a/compose/start-docker-compose-infrastructure.volumes.sh
+++ b/compose/start-docker-compose-infrastructure.volumes.sh
@@ -1,0 +1,1 @@
+docker-compose -f docker-compose-infrastructure.volumes.yml up


### PR DESCRIPTION
When using docker-compose with volumes is easier to delete or cleanup after work.
Command: docker-compose down -v with stop all services and delete volumes